### PR TITLE
feat: use MageOS Mirror to remove COMPOSER_AUTH requirement

### DIFF
--- a/.github/workflows/integration-README.md
+++ b/.github/workflows/integration-README.md
@@ -55,6 +55,4 @@ jobs:
       package_name: my-vendor/package
       matrix: ${{ needs.compute_matrix.outputs.matrix }}
       test_command: ../../../vendor/bin/phpunit ../../../vendor/my-vendor/package/Test/Integration
-    secrets:
-      composer_auth: ${{ secrets.COMPOSER_AUTH }}
 ```

--- a/.github/workflows/integration-README.md
+++ b/.github/workflows/integration-README.md
@@ -12,13 +12,13 @@ See the [integration.yaml](./integration.yaml)
 | package_name       | The name of the package                                       | true     | NULL                          |
 | source_folder      | The source folder of the package                              | false    | $GITHUB_WORKSPACE             |
 | magento_directory  | The folder where Magento will be installed                    | false    | ../magento2                   |
-| magento_repository | Where to install Magento from                                 | false    | https://repo.magento.com/     |
+| magento_repository | Where to install Magento from                                 | false    | https://mirror.mage-os.org/     |
 | test_command       | The integration test command to run                           | false    | "../../../vendor/bin/phpunit" |
 
 ## Secrets
 | Input         | Description                                                                                                                             | Required | Default |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
-| composer_auth | JSON string of [composer credentials]([#./matrix-format](https://devdocs.magento.com/guides/v2.4/install-gde/prereq/connect-auth.html)) | true     | NULL    |
+| composer_auth | JSON string of [composer credentials]([#./matrix-format](https://devdocs.magento.com/guides/v2.4/install-gde/prereq/connect-auth.html)) | false     | NULL    |
 
 ###  Matrix Format
 

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -22,7 +22,7 @@ on:
       magento_repository:
         type: string
         required: false
-        default: "https://repo.magento.com/"
+        default: "https://mirror.mage-os.org/"
         description: "Where to install Magento from"
 
       matrix:
@@ -38,7 +38,8 @@ on:
 
     secrets:
       composer_auth:
-        required: true
+        required: false
+        description: The COMPOSER_AUTH to use to install both your package and Magento.
 
 jobs:
   integration_test:

--- a/installation-test/README.md
+++ b/installation-test/README.md
@@ -42,7 +42,6 @@ jobs:
         composer_version: ${{ matrix.composer }}
         php_version: ${{ matrix.php }}
         magento_version: ${{ matrix.magento }}
-        composer_auth: ${{ secrets.COMPOSER_AUTH }}
         package_name: vendor/package
         source_folder: $GITHUB_WORKSPACE
 ```

--- a/installation-test/action.yml
+++ b/installation-test/action.yml
@@ -39,11 +39,11 @@ inputs:
     
   magento_repository:
     required: true
-    default: "https://repo.magento.com/"
+    default: "https://mirror.mage-os.org/"
     description: "Where to install Magento from"
   
   composer_auth:
-    required: true
+    required: false
     description: "Composer Authentication Credentials"
 
 runs:

--- a/unit-test/README.md
+++ b/unit-test/README.md
@@ -32,5 +32,4 @@ jobs:
     - uses: graycoreio/github-actions-magento2/unit-test@main
       with:
         php_version: ${{ matrix.php_version }}
-        composer_auth: ${{ secrets.COMPOSER_AUTH }}
 ```

--- a/unit-test/action.yml
+++ b/unit-test/action.yml
@@ -18,7 +18,7 @@ inputs:
     description: "The test command"
 
   composer_auth:
-    required: true
+    required: false
     description: "Composer Authentication Credentials"
 
 runs:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/magento2-github-actions/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, when you pull in the actions, you're required to use the Magento `https://repo.magento.com`. This means you have to add a `COMPOSER_AUTH` to your repo and PRs from Forks will not run (making this project less useful). 

Fixes: #9 


## What is the new behavior?
Instead, we depend on the MageOS Mirror, which does not have a COMPOSER_AUTH requirement.


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

If you want to use `https://repo.magento.com`, you can change the `magento_repository` back.

## Other information