### PR TITLE
feat: automatically allow the default Magento composer plugins

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -115,6 +115,14 @@ jobs:
       name: Fixup Monolog (https://github.com/magento/magento2/pull/35596)
       working-directory:  ${{ inputs.magento_directory }}
 
+    - run: | 
+        composer config --no-interaction allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+        composer config --no-interaction allow-plugins.laminas/laminas-dependency-plugin true
+        composer config --no-interaction allow-plugins.magento/* true
+      name: Fixup Composer Plugins
+      working-directory:  ${{ inputs.magento_directory }}
+      if: ${{ !startsWith(matrix.composer, '1') }}
+
     - run: composer require ${{ inputs.package_name }} "@dev" --no-update && composer install
       name: Require and attempt install
       working-directory:  ${{ inputs.magento_directory }}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/magento2-github-actions/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Integration tests will currently fail as a result of missing composer plugin allows on composer v2. 

Eventually this would result in an error like:

```bash
Error: An error occurred trying to start process '/usr/bin/bash' with working directory '/home/runner/work/github-actions-magento2/github-actions-magento2/../magento2/dev/tests/integration'. No such file or directory
```

with additional warnings like:

```bash
laminas/laminas-dependency-plugin contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe. See https://getcomposer.org/allow-plugins
You can run "composer config --no-plugins allow-plugins.laminas/laminas-dependency-plugin [true|false]" to enable it (true) or keep it disabled and suppress this warning (false)

dealerdirect/phpcodesniffer-composer-installer contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe. See https://getcomposer.org/allow-plugins
You can run "composer config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer [true|false]" to enable it (true) or keep it disabled and suppress this warning (false)

magento/composer-root-update-plugin contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe. See https://getcomposer.org/allow-plugins
You can run "composer config --no-plugins allow-plugins.magento/composer-root-update-plugin [true|false]" to enable it (true) or keep it disabled and suppress this warning (false)

magento/inventory-composer-installer contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe. See https://getcomposer.org/allow-plugins
You can run "composer config --no-plugins allow-plugins.magento/inventory-composer-installer [true|false]" to enable it (true) or keep it disabled and suppress this warning (false)

magento/magento-composer-installer contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe. See https://getcomposer.org/allow-plugins
You can run "composer config --no-plugins allow-plugins.magento/magento-composer-installer [true|false]" to enable it (true) or keep it disabled and suppress this warning (false)
```

Fixes: See https://github.com/graycoreio/github-actions-magento2/runs/7162488440?check_suite_focus=true

## What is the new behavior?
This adds the default composer plugins required by Magento.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information