### PR TITLE
fix(integration): force to explicitly older monolog versions (#12)

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -111,7 +111,7 @@ jobs:
       working-directory:  ${{ inputs.magento_directory }}
       shell: bash
 
-    - run: composer require monolog/monolog:"!=2.7.0" --no-update
+    - run: composer require monolog/monolog:"<2.7.0" --no-update
       name: Fixup Monolog (https://github.com/magento/magento2/pull/35596)
       working-directory:  ${{ inputs.magento_directory }}
 


### PR DESCRIPTION
See https://github.com/magento/magento2/issues/35604

Looks like this is a wontfix.

