### PR TITLE
Disable fail fast for integration tests

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -44,6 +44,7 @@ jobs:
   integration_test:
     runs-on:  ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix: ${{ fromJSON(inputs.matrix) }}
     services:
       elasticsearch:


### PR DESCRIPTION
Sometimes module doesn't support older magento versions due to dependencies.
In this case, when you trying to run integration tests for all versions - the not supported version starting fail, and it cancels runs for all other magento versions.
Example: 
<img width="349" alt="image" src="https://user-images.githubusercontent.com/1873745/183021605-aad488d6-8f48-4d7e-936d-bbc0523e78a0.png">


## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/graycoreio/github-actions-magento2/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
