### PR TITLE
feat: allow fail-fast as an input argument

### DIFF
--- a/.github/workflows/integration-README.md
+++ b/.github/workflows/integration-README.md
@@ -9,6 +9,7 @@ See the [integration.yaml](./integration.yaml)
 | Input              | Description                                                   | Required | Default                       |
 | ------------------ | ------------------------------------------------------------- | -------- | ----------------------------- |
 | matrix             | JSON string of [version matrix for Magento](./#matrix-format) | true     | NULL                          |
+| fail-fast          | Same as Github's [fail-fast](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast)  | false     | true                          |
 | package_name       | The name of the package                                       | true     | NULL                          |
 | source_folder      | The source folder of the package                              | false    | $GITHUB_WORKSPACE             |
 | magento_directory  | The folder where Magento will be installed                    | false    | ../magento2                   |
@@ -18,7 +19,7 @@ See the [integration.yaml](./integration.yaml)
 ## Secrets
 | Input         | Description                                                                                                                             | Required | Default |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
-| composer_auth | JSON string of [composer credentials]([#./matrix-format](https://devdocs.magento.com/guides/v2.4/install-gde/prereq/connect-auth.html)) | true     | NULL    |
+| composer_auth | JSON string of [composer credentials]([#./matrix-format](https://devdocs.magento.com/guides/v2.4/install-gde/prereq/connect-auth.html)) | false     | NULL    |
 
 ###  Matrix Format
 

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -29,6 +29,11 @@ on:
         type: string
         required: true
         description: "The matrix of Magento versions to test against"
+
+      fail_fast:
+        type: boolean
+        required: false
+        default: true
       
       test_command:
         type: string
@@ -44,6 +49,7 @@ jobs:
   integration_test:
     runs-on:  ${{ matrix.os }}
     strategy:
+      fail-fast: ${{ inputs.fail_fast }}
       matrix: ${{ fromJSON(inputs.matrix) }}
     services:
       elasticsearch:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -30,7 +30,7 @@ on:
         required: true
         description: "The matrix of Magento versions to test against"
 
-      fail_fast:
+      fail-fast:
         type: boolean
         required: false
         default: true
@@ -49,7 +49,7 @@ jobs:
   integration_test:
     runs-on:  ${{ matrix.os }}
     strategy:
-      fail-fast: ${{ inputs.fail_fast }}
+      fail-fast: ${{ inputs.fail-fast }}
       matrix: ${{ fromJSON(inputs.matrix) }}
     services:
       elasticsearch:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -33,7 +33,7 @@ on:
       fail_fast:
         type: boolean
         required: false
-        default: true
+        default: false
       
       test_command:
         type: string

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -33,7 +33,7 @@ on:
       fail_fast:
         type: boolean
         required: false
-        default: false
+        default: true
       
       test_command:
         type: string


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/github-actions-magento2/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, we [`fail-fast`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) during builds which can be annoying when you're trying to fix multiple versions at the same time and you have to run the build frequently to know what is wrong with each version.

Fixes: N/A


## What is the new behavior?
We still fail-fast, but users can change the behavior.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
