### PR TITLE
fix(integration): only run monolog fixup on v2.4.4

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -97,6 +97,16 @@ jobs:
         COMPOSER_AUTH: ${{ secrets.composer_auth }}
       name: Create Magento ${{ matrix.magento }} Project 
 
+    - run: |
+        echo "::set-output name=version::$(cat composer.json | jq '.require 
+        | with_entries( select(.key == "magento/product-community-edition" or .key == "magento/product-enterprise-edition") )
+        | to_entries 
+        | .[0].value')"
+      shell: bash
+      working-directory:  ${{ inputs.magento_directory }}
+      name: Compute Installable Magento version
+      id: magento-version
+
     - name: Get Composer Cache Directory
       shell: bash
       working-directory:  ${{ inputs.magento_directory }}
@@ -118,6 +128,8 @@ jobs:
     - run: composer require monolog/monolog:"<2.7.0" --no-update
       name: Fixup Monolog (https://github.com/magento/magento2/pull/35596)
       working-directory:  ${{ inputs.magento_directory }}
+      if: |
+        steps.magento-version.outputs.version == '"2.4.4"'
 
     - run: | 
         composer config --no-interaction allow-plugins.dealerdirect/phpcodesniffer-composer-installer true


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/github-actions-magento2/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, we change the monolog version on ALL Magento versions. This is a mistake.

Fixes: N/A


## What is the new behavior?
We now only apply the change on v2.4.4.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
