### PR TITLE
feat: make cache key consistent (and configurable)

### DIFF
--- a/.github/workflows/integration-README.md
+++ b/.github/workflows/integration-README.md
@@ -6,20 +6,21 @@ A Github Workflow that runs the Integration Tests of a Magento Package
 
 See the [integration.yaml](./integration.yaml)
 
-| Input              | Description                                                   | Required | Default                       |
-| ------------------ | ------------------------------------------------------------- | -------- | ----------------------------- |
-| matrix             | JSON string of [version matrix for Magento](./#matrix-format) | true     | NULL                          |
-| fail-fast          | Same as Github's [fail-fast](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast)  | false     | true                          |
-| package_name       | The name of the package                                       | true     | NULL                          |
-| source_folder      | The source folder of the package                              | false    | $GITHUB_WORKSPACE             |
-| magento_directory  | The folder where Magento will be installed                    | false    | ../magento2                   |
-| magento_repository | Where to install Magento from                                 | false    | https://mirror.mage-os.org/   |
-| test_command       | The integration test command to run                           | false    | "../../../vendor/bin/phpunit" |
+| Input              | Description                                                                                                                                     | Required | Default                       |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------------- |
+| matrix             | JSON string of [version matrix for Magento](./#matrix-format)                                                                                   | true     | NULL                          |
+| fail-fast          | Same as Github's [fail-fast](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) | false    | true                          |
+| package_name       | The name of the package                                                                                                                         | true     | NULL                          |
+| source_folder      | The source folder of the package                                                                                                                | false    | $GITHUB_WORKSPACE             |
+| magento_directory  | The folder where Magento will be installed                                                                                                      | false    | ../magento2                   |
+| magento_repository | Where to install Magento from                                                                                                                   | false    | https://mirror.mage-os.org/   |
+| test_command       | The integration test command to run                                                                                                             | false    | "../../../vendor/bin/phpunit" |
+| composer_cache_key | A key to version the composer cache. Can be incremented if you need to bust the cache.                                                          | false    | ""                            |
 
 ## Secrets
 | Input         | Description                                                                                                                             | Required | Default |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
-| composer_auth | JSON string of [composer credentials]([#./matrix-format](https://devdocs.magento.com/guides/v2.4/install-gde/prereq/connect-auth.html)) | false     | NULL    |
+| composer_auth | JSON string of [composer credentials]([#./matrix-format](https://devdocs.magento.com/guides/v2.4/install-gde/prereq/connect-auth.html)) | false    | NULL    |
 
 ###  Matrix Format
 

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -41,6 +41,12 @@ on:
         default: ../../../vendor/bin/phpunit
         description: "The integration test command to run"
 
+      composer_cache_key:
+        type: string
+        required: false
+        default: ''
+        description: A key to version the composer cache. Can be incremented if you need to bust the cache.
+
     secrets:
       composer_auth:
         required: false
@@ -117,7 +123,7 @@ jobs:
     - name: "Cache Composer Packages"
       uses: actions/cache@v3
       with:
-        key: 'composer | v3 | "$(Agent.OS)"  | composer.lock | ${{ matrix.composer }} | ${{ matrix.php }} | ${{ matrix.magento }}' 
+        key: "composer | v4 | ${{ inputs.composer_cache_key }} | ${{ hashFiles('composer.lock') }} | ${{ matrix.os }} | ${{ matrix.composer }} | ${{ matrix.php }} | ${{ matrix.magento }}"
         path: ${{ steps.composer-cache.outputs.dir }}
 
     - run: composer config repositories.local path ${{ inputs.source_folder }}

--- a/installation-test/action.yml
+++ b/installation-test/action.yml
@@ -41,6 +41,11 @@ inputs:
     required: true
     default: "https://mirror.mage-os.org/"
     description: "Where to install Magento from"
+
+  composer_cache_key:
+    required: false
+    default: ''
+    description: A key to version the composer cache. Can be incremented if you need to bust the cache.
   
   composer_auth:
     required: false
@@ -74,7 +79,7 @@ runs:
     - name: "Cache Composer Packages"
       uses: actions/cache@v3
       with:
-        key: 'composer | v3 | "$(Agent.OS)"  | composer.lock | ${{ inputs.composer_version }} | ${{ inputs.php_version }} | ${{ inputs.magento_version }}' 
+        key: "composer | v4 | ${{ inputs.composer_cache_key }} | ${{ hashFiles('composer.lock') }} | ${{ runner.os }} | ${{ inputs.composer_version }} | ${{ inputs.php_version }} | ${{ inputs.magento_version }}"
         path: ${{ steps.composer-cache.outputs.dir }}
 
     - run: composer config repositories.local path ${{ inputs.source_folder }}

--- a/unit-test/action.yml
+++ b/unit-test/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: "Cache Composer Packages"
       uses: actions/cache@v3
       with:
-        key: 'composer | v3 | "$(Agent.OS)"  | composer.lock | ${{ inputs.php_version }}' 
+        key: "composer | v3 | ${{ hashFiles('composer.lock') }} | ${{ runner.os }} | ${{ inputs.php_version }}"
         path: ${{ steps.composer-cache.outputs.dir }}
 
     - run: composer install


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/github-actions-magento2/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, in MageOS, there's a strong use-case for cache-busting the internal composer cache if there's a need to fixup broken composer packages. While, rare, it happens. We need to support cache-busting by consumers.

Fixes: N/A

## What is the new behavior?
You can now defined a `composer_cache_key` (a string) which allows you to change/bust the cache as you wish.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
