### PR TITLE
feat: add coding standard action

### DIFF
--- a/.github/workflows/_internal-coding-standard.yaml
+++ b/.github/workflows/_internal-coding-standard.yaml
@@ -1,0 +1,41 @@
+name: Coding Standard
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - "_test/demo-package/**"
+    - ".github/workflows/_internal-coding-standard.yaml"
+    - "coding-standard/**"
+    - "!(**/*.md)"
+  pull_request:
+    branches:
+    - main
+    paths:
+    - "_test/demo-package/**"
+    - ".github/workflows/_internal-coding-standard.yaml"
+    - "coding-standard/**"
+    - "!(**/*.md)"
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        default: '*'
+        description: The version of the coding standard to use.
+        required: false
+      path:
+        type: string
+        default: '_test/demo-package'
+        description: Path to run the coding standard on.
+        required: true
+
+jobs:
+  coding-standard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: './coding-standard'
+        with:
+          version: ${{ github.event.inputs.version || '*' }}
+          path: ${{ github.event.inputs.path || '_test/demo-package' }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea/

--- a/coding-standard/README.md
+++ b/coding-standard/README.md
@@ -1,0 +1,30 @@
+# Magento 2 Coding Standard Action
+
+A Github Action that runs the Magento Coding Standard.
+
+## Inputs
+
+See the [action.yml](./action.yml)
+
+## Usage
+
+```yml
+name: Coding Standard
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  coding-standard:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: graycoreio/github-actions-magento2/coding-standard@main
+      with:
+        version: 25 # Optional, will use the latest if omitted.
+        path: app/code # Optional, will be used when event is not a pull request.
+```

--- a/coding-standard/action.yml
+++ b/coding-standard/action.yml
@@ -1,0 +1,65 @@
+name: "Coding Standard"
+author: "Graycore"
+description: "A Github Action that runs the Magento Coding Standard."
+
+inputs:
+  php_version:
+    required: true
+    default: "8.1"
+    description: "PHP version used to do the coding standard check."
+
+  composer_version:
+    required: true
+    default: "2"
+    description: "The version of composer to use."
+
+  path:
+    required: true
+    default: 'app/code'
+    description: "The directory (relative to the project root) in which the coding standard will be checked. Used when the event is not a pull request."
+
+  version:
+    required: false
+    description: "The version of the coding standard to use. If not provided, will use the latest version."
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout Project
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        path: project
+
+    - name: Create Standard Directory
+      shell: bash
+      run: mkdir standard
+
+    - name: Set PHP Version
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.php_version }}
+        tools: composer:v${{ inputs.composer_version }}
+        coverage: none
+
+    - name: Install Coding Standard
+      shell: bash
+      working-directory: standard
+      run: composer require "magento/magento-coding-standard:${{ inputs.version || '*' }}"
+
+    - name: Register Coding Standard
+      shell: bash
+      working-directory: standard
+      run: vendor/bin/phpcs --config-set installed_paths ${{ github.workspace }}/standard/vendor/magento/magento-coding-standard,${{ github.workspace }}/standard/vendor/phpcompatibility/php-compatibility
+
+    - name: Get Changed Files
+      shell: bash
+      working-directory: project
+      id: changed-files
+      run: echo "::set-output name=files::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | xargs)"
+      if: github.event_name == 'pull_request'
+
+    - name: Coding Standard Check
+      shell: bash
+      run: ../standard/vendor/bin/phpcs --standard=Magento2 ${{ github.event_name == 'pull_request' && steps.changed-files.outputs.files || inputs.path }}
+      working-directory: project


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/github-actions-magento2/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

N/A

## What is the new behavior?

Adds an action for running the [Magento Coding Standard](https://github.com/magento/magento-coding-standard).

On Pull Requests, it will only check affected files. On any other event, a `path` input can be provided.

Additionally I added an internal workflow to be able to test manually.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
