### PR TITLE
fix: use local path source_folder if not empty

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -130,6 +130,7 @@ jobs:
       name: Add Github Repo for Testing
       working-directory:  ${{ inputs.magento_directory }}
       shell: bash
+      if: ${{ inputs.source_folder != "" }}
 
     - run: composer require monolog/monolog:"<2.7.0" --no-update
       name: Fixup Monolog (https://github.com/magento/magento2/pull/35596)

--- a/installation-test/action.yml
+++ b/installation-test/action.yml
@@ -86,6 +86,7 @@ runs:
       name: Add Github Repo for Testing
       working-directory:  ${{ inputs.magento_directory }}
       shell: bash
+      if: ${{ inputs.source_folder != "" }}
 
     - run: |
         composer config --no-interaction allow-plugins.dealerdirect/phpcodesniffer-composer-installer true


### PR DESCRIPTION
This allows using the action in https://github.com/mage-os/generate-mirror-repo-js where the test module is an external package installed with composer. In this case, no local path repo configuration is needed.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/github-actions-magento2/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently the action fails if the local repo path url points to a non-existing folder or to a folder without a composer.json file.


## What is the new behavior?

The action completes since no local path repo is configured


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
