### PR TITLE
feat: use new 'setup-magento' in installation-test

### DIFF
--- a/installation-test/action.yml
+++ b/installation-test/action.yml
@@ -59,56 +59,30 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set PHP Version
-      uses: shivammathur/setup-php@v2
+    - uses: graycoreio/github-actions-magento2/setup-magento@main
+      id: setup-magento
       with:
         php-version: ${{ inputs.php_version }}
+        tools: composer:v${{ inputs.composer_version }}
+        mode: extension
+        magento_version: ${{ inputs.magento_version }}
 
-    - run: composer self-update --${{ inputs.composer_version }}
-      name: Pin to Composer Version ${{ inputs.composer_version }}
-      shell: bash
-
-    - run: composer create-project --repository-url="${{ inputs.magento_repository }}" "${{ inputs.magento_version }}" ${{ inputs.magento_directory }} --no-install
-      shell: bash
-      env:
-        COMPOSER_AUTH: ${{ inputs.composer_auth }}
-      name: Create Magento ${{ inputs.magento_version }} Project 
-
-    - name: Get Composer Cache Directory
-      shell: bash
-      working-directory:  ${{ inputs.magento_directory }}
-      id: composer-cache
-      run: |
-        echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-
-    - name: "Cache Composer Packages"
-      uses: actions/cache@v3
+    - uses: graycoreio/github-actions-magento2/cache-magento@main
       with:
-        key: "composer | v5 | ${{ inputs.composer_cache_key }} | ${{ hashFiles('composer.lock') }} | ${{ runner.os }} | ${{ inputs.composer_version }} | ${{ inputs.php_version }} | ${{ inputs.magento_version }}"
-        path: ${{ steps.composer-cache.outputs.dir }}
-
+        mode: 'extension'
+        composer_cache_key: ${{ inputs.magento_version }}
+    
     - run: composer config repositories.local path ${{ inputs.source_folder }}
       name: Add Github Repo for Testing
-      working-directory:  ${{ inputs.magento_directory }}
+      working-directory: ${{ steps.setup-magento.outputs.path }}
       shell: bash
       if: ${{ inputs.use_local_source == 'true' }}
 
-    - run: |
-        composer config --no-interaction allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-        composer config --no-interaction allow-plugins.laminas/laminas-dependency-plugin true
-        composer config --no-interaction allow-plugins.magento/* true
-      name: Fixup Composer Plugins
-      shell: bash
-      working-directory:  ${{ inputs.magento_directory }}
-      if: ${{ !startsWith(inputs.composer_version, '1') }}
-    
-    - run: composer require ${{ inputs.package_name }} "@dev" --no-update && composer install
-      name: Require and attempt install
-      working-directory:  ${{ inputs.magento_directory }}
+    - run: composer require ${{ inputs.package_name }} "@dev"
+      name: Attempt install
+      working-directory: ${{ steps.setup-magento.outputs.path }}
       shell: bash
       env:
-        COMPOSER_CACHE_DIR: ${{ steps.composer-cache.outputs.dir }}
         COMPOSER_AUTH: ${{ inputs.composer_auth }}
 
 branding:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/github-actions-magento2/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
We now have a standard `setup-magento`, so we use it.

Fixes: N/A


## What is the new behavior?
We use `setup-magento`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
