### PR TITLE
feat: make phpcs severity level configurable

### DIFF
--- a/coding-standard/README.md
+++ b/coding-standard/README.md
@@ -27,4 +27,7 @@ jobs:
       with:
         version: 25 # Optional, will use the latest if omitted.
         path: app/code # Optional, will be used when event is not a pull request.
+        severity: 8 # Optional, will use phpcs default of 5 if not specified.
+        warning_severity: 4 # Optional, will use severity value if not specified.
+        error_severity: 7 # Optional, will use severity value if not specified.
 ```

--- a/coding-standard/action.yml
+++ b/coding-standard/action.yml
@@ -21,6 +21,21 @@ inputs:
   version:
     required: false
     description: "The version of the coding standard to use. If not provided, will use the latest version."
+    
+  severity:
+    required: false
+    default: ""
+    description: "The minimum severity required to display an error or warning (default: 5)"
+  
+  warning_severity:
+    required: false
+    default: ""
+    description: "The minimum severity required to display a warning"
+  
+  error_severity:
+    required: false
+    default: ""
+    description: "The minimum severity required to display an error"
 
 runs:
   using: composite
@@ -61,5 +76,10 @@ runs:
 
     - name: Coding Standard Check
       shell: bash
-      run: ../standard/vendor/bin/phpcs --standard=Magento2 ${{ github.event_name == 'pull_request' && steps.changed-files.outputs.files || inputs.path }}
+      run: |
+        ../standard/vendor/bin/phpcs --standard=Magento2 \
+        $([ -n "${{ inputs.severity }}" ] && echo "--severity=${{ inputs.severity }}") \
+        $([ -n "${{ inputs.warning_severity }}" ] && echo "--warning-severity=${{ inputs.warning_severity }}") \
+        $([ -n "${{ inputs.error_severity }}" ] && echo "--error-severity=${{ inputs.error_severity }}") \
+        ${{ github.event_name == 'pull_request' && steps.changed-files.outputs.files || inputs.path }}
       working-directory: project


### PR DESCRIPTION
Add inputs to allow configuring error and warning severity levels.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/github-actions-magento2/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
The phpcs command is always executed with the built in default severity level 5.


Fixes: N/A

## What is the new behavior?
Three new optional inputs allow specifying the error and warning severity level.  
This allows suppressing messages in the Mage-OS repository that are ignored in upstream Magento Open Source CI, too.

If no values are specified the built in default value is used.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
Reference Mage-OS PR https://github.com/mage-os/mageos-magento2/pull/22

