### PR TITLE
fix(coding-standard)!: use magento/php-compatibility-fork

### DIFF
--- a/coding-standard/README.md
+++ b/coding-standard/README.md
@@ -2,6 +2,9 @@
 
 A Github Action that runs the Magento Coding Standard.
 
+> [!WARNING]
+> This action is only compatible with Magento v2.4.4+.
+
 ## Inputs
 
 See the [action.yml](./action.yml)

--- a/coding-standard/action.yml
+++ b/coding-standard/action.yml
@@ -87,7 +87,7 @@ runs:
     - name: Register Coding Standard
       shell: bash
       working-directory: standard
-      run: vendor/bin/phpcs --config-set installed_paths ${{ github.workspace }}/standard/vendor/magento/magento-coding-standard,${{ github.workspace }}/standard/vendor/phpcompatibility/php-compatibility
+      run: vendor/bin/phpcs --config-set installed_paths ${{ github.workspace }}/standard/vendor/magento/magento-coding-standard,${{ github.workspace }}/standard/vendor/magento/php-compatibility-fork
 
     - name: Set ignore warnings flag
       shell: bash


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/github-actions-magento2/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, the coding standard actions are failing due to a problem with `phpcompatibility/php-compatibility` that resulted in a fork by Adobe: `magento/php-compatibility-fork`.

Fixes: N/A


## What is the new behavior?
We use the new fork.


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

This MAY be a breaking change if you depended on something specifically from `phpcompatibility/php-compatibility`. Additionally, this action is no longer compatible with Magento < 2.4.4.

## Other information
