### PR TITLE
fix(supported-version)!: default include_services to true

### DIFF
--- a/supported-version/action.yml
+++ b/supported-version/action.yml
@@ -24,7 +24,7 @@ inputs:
 
   include_services:
     required: false
-    default: "false"
+    default: "true"
     description: "Whether to include a `services` key in each matrix entry with GitHub Actions service configurations."
 
 outputs:


### PR DESCRIPTION
## Summary

- Flips `include_services` default from `"false"` to `"true"` in `supported-version/action.yml`.
- Unblocks every external caller that pipes the default `supported-version` matrix into `check-extension.yaml` or `integration.yaml` — both reference `${{ matrix.services }}` unconditionally (silent failure on v5.1.0, template validation error on v6.0.0).
- No TS/`dist/` changes needed: the default is consumed at the `action.yml` layer before the bundled entrypoint runs.

## Why this is the right shape

The alternative — making the downstream workflows tolerate a missing `services` key — either removes service wiring from integration tests (breaking them) or requires a second `supported-version` call inside those workflows. Flipping the default is one line and matches what every internal CI workflow (`_internal-integration.yaml`, `_internal_check_extension.yaml`) already opts into explicitly.

## Breaking change

Marked `!` because the matrix output gains a new top-level key by default. Callers that strictly schema-validate the matrix or run in a constrained environment without the services ports open can restore the previous behavior with `include_services: false`.

## Test plan

- [x] `npm test` (100/100 green — no spec depends on the default value)
- [ ] CI: `_internal_check_extension.yaml` and `_internal-integration.yaml` continue passing with their existing `include_services: true` (behavior identical) 
- [ ] Manually confirm an external caller dropping the `include_services` input no longer hits the template error

Closes #214