### PR TITLE
fix(check-extension): probe vendor dir for phpcs installed_paths

### DIFF
--- a/.github/workflows/check-extension.yaml
+++ b/.github/workflows/check-extension.yaml
@@ -182,7 +182,18 @@ jobs:
       - name: Register Coding Standard
         shell: bash
         working-directory: ${{ inputs.path }}
-        run: vendor/bin/phpcs --config-set installed_paths vendor/magento/magento-coding-standard,vendor/magento/php-compatibility-fork
+        run: |
+          if [ -d vendor/magento/magento-coding-standard ]; then
+            CODING_STANDARD_VENDOR=magento
+          elif [ -d vendor/mage-os/magento-coding-standard ]; then
+            CODING_STANDARD_VENDOR=mage-os
+          else
+            echo "No magento-coding-standard directory found under vendor/magento or vendor/mage-os."
+            echo "Trusting dealerdirect/phpcodesniffer-composer-installer to have registered installed_paths."
+            exit 0
+          fi
+          vendor/bin/phpcs --config-set installed_paths \
+            "vendor/${CODING_STANDARD_VENDOR}/magento-coding-standard,vendor/${CODING_STANDARD_VENDOR}/php-compatibility-fork"
 
       - name: Coding Standard Check
         shell: bash


### PR DESCRIPTION
## Summary

- `check-extension.yaml`'s Register Coding Standard step hardcoded `vendor/magento/...` when calling `phpcs --config-set installed_paths`.
- Mage-OS composer repositories alias `magento/*` → `mage-os/*`, so `composer require magento/magento-coding-standard magento/php-compatibility-fork` physically lands under `vendor/mage-os/...`. The hardcoded path clobbered what `dealerdirect/phpcodesniffer-composer-installer` had correctly written during install, yielding `Referenced sniff "Magento2" does not exist` / `No sniffs were registered`.
- Now: probe `vendor/magento/magento-coding-standard` first (preserves existing behavior on vanilla Magento Open Source), fall back to `vendor/mage-os/magento-coding-standard`, otherwise skip the explicit `--config-set` and trust dealerdirect's auto-registration.

## Why the probe over "just delete the line"

Deletion is cleaner but relies on the dealerdirect plugin running. The workflow only globally allows that plugin for composer <2.2 (`is-allow-plugins-available.outputs.result < 1`). On modern composer, the plugin may be blocked and the explicit `--config-set` is what makes phpcs work today. A probe keeps the safety net while unblocking mage-os callers.

## Test plan

- [ ] Vanilla Magento Open Source extension: coding-standard job behavior unchanged (first `if` branch hits).
- [ ] Mage-OS extension (e.g. `mage-os-lab/module-ai-base`): coding-standard job registers `vendor/mage-os/...` and `phpcs` finds the `Magento2` ruleset.
- [ ] Neither vendor dir present (edge case): job no longer hard-fails — dealerdirect's registration is trusted.

Closes #213