### PR TITLE
feat(coding-standard)!: remove pr-diff feature and built-in php setup

### DIFF
--- a/.github/workflows/_internal-coding-standard.yaml
+++ b/.github/workflows/_internal-coding-standard.yaml
@@ -51,9 +51,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v${{ matrix.composer }}
+          coverage: none
+
       - uses: './coding-standard'
         with:
           version: ${{ github.event.inputs.version || '*' }}
           path: ${{ github.event.inputs.path || '_test/demo-package' }}
-          composer_version: ${{ matrix.composer }}
-          php_version: ${{ matrix.php }}

--- a/.github/workflows/check-extension.yaml
+++ b/.github/workflows/check-extension.yaml
@@ -152,56 +152,16 @@ jobs:
           fail-fast: ${{ inputs.fail-fast }}
       steps:
       - uses: actions/checkout@v6
-          
-      - name: Get Composer Version
-        uses: graycoreio/github-actions-magento2/get-composer-version@main
-        id: get-composer-version
 
-      - name: Check if allow-plugins option is available for this version of composer
-        uses: graycoreio/github-actions-magento2/semver-compare@main
+      - uses: shivammathur/setup-php@v2
         with:
-          version: 2.2
-          compare_against: ${{ steps.get-composer-version.outputs.version }}
-        id: is-allow-plugins-available
+          php-version: ${{ matrix.php }}
+          tools: composer:v${{ matrix.composer }}
+          coverage: none
 
-      - name: Enable dealerdirect/phpcodesniffer-composer-installer plugin
-        shell: bash
-        working-directory: ${{ inputs.path }}
-        run: composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer  true --global
-        if: steps.is-allow-plugins-available.outputs.result < 1
-
-      - name: Install Coding Standard
-        shell: bash
-        working-directory: ${{ inputs.path }}
-        run: composer require "magento/magento-coding-standard" "magento/php-compatibility-fork"
-        env:
-          COMPOSER_AUTH: ${{ secrets.composer_auth }}
-
-      - name: Register Coding Standard
-        shell: bash
-        working-directory: ${{ inputs.path }}
-        run: |
-          if [ -d vendor/magento/magento-coding-standard ]; then
-            CODING_STANDARD_VENDOR=magento
-          elif [ -d vendor/mage-os/magento-coding-standard ]; then
-            CODING_STANDARD_VENDOR=mage-os
-          else
-            echo "No magento-coding-standard directory found under vendor/magento or vendor/mage-os."
-            echo "Trusting dealerdirect/phpcodesniffer-composer-installer to have registered installed_paths."
-            exit 0
-          fi
-          vendor/bin/phpcs --config-set installed_paths \
-            "vendor/${CODING_STANDARD_VENDOR}/magento-coding-standard,vendor/${CODING_STANDARD_VENDOR}/php-compatibility-fork"
-
-      - name: Coding Standard Check
-        shell: bash
-        run: |
-          if [ -f .phpcs.xml ] || [ -f phpcs.xml ] || [ -f .phpcs.xml.dist ] || [ -f phpcs.xml.dist ]; then
-            ./vendor/bin/phpcs .
-          else
-            ./vendor/bin/phpcs --standard=Magento2 --ignore=*vendor/* .
-          fi
-        working-directory: ${{ inputs.path }}
+      - uses: graycoreio/github-actions-magento2/coding-standard@main
+        with:
+          path: ${{ inputs.path }}
 
     integration_test:
       runs-on:  ${{ matrix.os }}

--- a/coding-standard/README.md
+++ b/coding-standard/README.md
@@ -11,6 +11,8 @@ See the [action.yml](./action.yml)
 
 ## Usage
 
+The caller is responsible for checking out the repository and setting up PHP before calling this action.
+
 ```yml
 name: Coding Standard
 
@@ -26,10 +28,18 @@ jobs:
   coding-standard:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v6
+
+    - uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.3'
+        tools: composer:v2
+        coverage: none
+
     - uses: graycoreio/github-actions-magento2/coding-standard@main
       with:
+        path: app/code # Optional, defaults to .
         version: 25 # Optional, will use the latest if omitted.
-        path: app/code # Optional, will be used when event is not a pull request.
         severity: 8 # Optional, will use phpcs default of 5 if not specified.
         warning_severity: 4 # Optional, will use severity value if not specified.
         error_severity: 7 # Optional, will use severity value if not specified.

--- a/coding-standard/action.yml
+++ b/coding-standard/action.yml
@@ -3,35 +3,25 @@ author: "Graycore"
 description: "A Github Action that runs the Magento Coding Standard."
 
 inputs:
-  php_version:
-    required: true
-    default: "8.1"
-    description: "PHP version used to do the coding standard check."
-
-  composer_version:
-    required: true
-    default: "2"
-    description: "The version of composer to use."
-
   path:
     required: true
-    default: 'app/code'
-    description: "The directory (relative to the project root) in which the coding standard will be checked. Used when the event is not a pull request."
+    default: '.'
+    description: "The directory containing the code to check."
 
   version:
     required: false
     description: "The version of the coding standard to use. If not provided, will use the latest version."
-    
+
   severity:
     required: false
     default: ""
     description: "The minimum severity required to display an error or warning (default: 5)"
-  
+
   warning_severity:
     required: false
     default: ""
     description: "The minimum severity required to display a warning"
-  
+
   error_severity:
     required: false
     default: ""
@@ -45,69 +35,64 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout Project
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-        path: project
-
-    - name: Create Standard Directory
-      shell: bash
-      run: mkdir standard
-
-    - name: Set PHP Version
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ inputs.php_version }}
-        tools: composer:v${{ inputs.composer_version }}
-        coverage: none
-
     - name: Get Composer Version
       uses: graycoreio/github-actions-magento2/get-composer-version@main
       id: get-composer-version
 
     - name: Check if allow-plugins option is available for this version of composer
       uses: graycoreio/github-actions-magento2/semver-compare@main
+      id: is-allow-plugins-available
       with:
         version: 2.2
         compare_against: ${{ steps.get-composer-version.outputs.version }}
-      id: is-allow-plugins-available
 
     - name: Enable dealerdirect/phpcodesniffer-composer-installer plugin
       shell: bash
-      working-directory: standard
-      run: composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer  true --global
+      working-directory: ${{ inputs.path }}
+      run: composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true --global
       if: steps.is-allow-plugins-available.outputs.result < 1
 
     - name: Install Coding Standard
       shell: bash
-      working-directory: standard
-      run: composer require "magento/magento-coding-standard:${{ inputs.version || '*' }}"
+      working-directory: ${{ inputs.path }}
+      run: composer require "magento/magento-coding-standard:${{ inputs.version || '*' }}" "magento/php-compatibility-fork"
 
     - name: Register Coding Standard
       shell: bash
-      working-directory: standard
-      run: vendor/bin/phpcs --config-set installed_paths ${{ github.workspace }}/standard/vendor/magento/magento-coding-standard,${{ github.workspace }}/standard/vendor/magento/php-compatibility-fork
+      working-directory: ${{ inputs.path }}
+      run: |
+        if [ -d vendor/magento/magento-coding-standard ]; then
+          CODING_STANDARD_VENDOR=magento
+        elif [ -d vendor/mage-os/magento-coding-standard ]; then
+          CODING_STANDARD_VENDOR=mage-os
+        else
+          echo "No magento-coding-standard directory found under vendor/magento or vendor/mage-os."
+          echo "Trusting dealerdirect/phpcodesniffer-composer-installer to have registered installed_paths."
+          exit 0
+        fi
+        vendor/bin/phpcs --config-set installed_paths \
+          "vendor/${CODING_STANDARD_VENDOR}/magento-coding-standard,vendor/${CODING_STANDARD_VENDOR}/php-compatibility-fork"
 
     - name: Set ignore warnings flag
       shell: bash
-      working-directory: standard
+      working-directory: ${{ inputs.path }}
       run: vendor/bin/phpcs --config-set ignore_warnings_on_exit 1
       if: inputs.ignore_warnings == 'true'
 
-    - name: Get Changed Files
-      shell: bash
-      working-directory: project
-      id: changed-files
-      run: echo "files=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | xargs)" >> $GITHUB_OUTPUT
-      if: github.event_name == 'pull_request'
-
     - name: Coding Standard Check
       shell: bash
+      working-directory: ${{ inputs.path }}
       run: |
-        ../standard/vendor/bin/phpcs --standard=Magento2 \
-        $([ -n "${{ inputs.severity }}" ] && echo "--severity=${{ inputs.severity }}") \
-        $([ -n "${{ inputs.warning_severity }}" ] && echo "--warning-severity=${{ inputs.warning_severity }}") \
-        $([ -n "${{ inputs.error_severity }}" ] && echo "--error-severity=${{ inputs.error_severity }}") \
-        ${{ github.event_name == 'pull_request' && steps.changed-files.outputs.files || inputs.path }}
-      working-directory: project
+        SEVERITY_FLAGS="$([ -n "${{ inputs.severity }}" ] && echo "--severity=${{ inputs.severity }}") \
+          $([ -n "${{ inputs.warning_severity }}" ] && echo "--warning-severity=${{ inputs.warning_severity }}") \
+          $([ -n "${{ inputs.error_severity }}" ] && echo "--error-severity=${{ inputs.error_severity }}")"
+
+        if [ -f .phpcs.xml ] || [ -f phpcs.xml ] || [ -f .phpcs.xml.dist ] || [ -f phpcs.xml.dist ]; then
+          vendor/bin/phpcs ${SEVERITY_FLAGS} .
+        else
+          vendor/bin/phpcs --standard=Magento2 --ignore=*vendor/* ${SEVERITY_FLAGS} .
+        fi
+
+branding:
+  icon: "code"
+  color: "green"

--- a/coding-standard/action.yml
+++ b/coding-standard/action.yml
@@ -83,14 +83,15 @@ runs:
       shell: bash
       working-directory: ${{ inputs.path }}
       run: |
-        SEVERITY_FLAGS="$([ -n "${{ inputs.severity }}" ] && echo "--severity=${{ inputs.severity }}") \
-          $([ -n "${{ inputs.warning_severity }}" ] && echo "--warning-severity=${{ inputs.warning_severity }}") \
-          $([ -n "${{ inputs.error_severity }}" ] && echo "--error-severity=${{ inputs.error_severity }}")"
+        FLAGS=()
+        [ -n "${{ inputs.severity }}" ] && FLAGS+=(--severity=${{ inputs.severity }}) || true
+        [ -n "${{ inputs.warning_severity }}" ] && FLAGS+=(--warning-severity=${{ inputs.warning_severity }}) || true
+        [ -n "${{ inputs.error_severity }}" ] && FLAGS+=(--error-severity=${{ inputs.error_severity }}) || true
 
         if [ -f .phpcs.xml ] || [ -f phpcs.xml ] || [ -f .phpcs.xml.dist ] || [ -f phpcs.xml.dist ]; then
-          vendor/bin/phpcs ${SEVERITY_FLAGS} .
+          vendor/bin/phpcs "${FLAGS[@]}" .
         else
-          vendor/bin/phpcs --standard=Magento2 --ignore=*vendor/* ${SEVERITY_FLAGS} .
+          vendor/bin/phpcs --standard=Magento2 --ignore=*vendor/* "${FLAGS[@]}" .
         fi
 
 branding:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/github-actions-magento2/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently `coding-standard` [does way too much initial setup work.](https://github.com/graycoreio/github-actions-magento2/blob/main/docs/action-design.md) It also force PR-diff check-only behaviors without opt-in.

Fixes: N/A


## What is the new behavior?
I've removed much of the "setup" that's built-into the command in favor of a leaner action. I've also removed the PR-diff behavior. This can be restored, but it shouldn't be the default and should be done as an input.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
