### PR TITLE
Address `set-output` deprecation

### DIFF
--- a/cache-magento/action.yml
+++ b/cache-magento/action.yml
@@ -26,11 +26,11 @@ runs:
       run: |
         echo "dir=$(composer config cache-files-dir --global)" >> $GITHUB_OUTPUT
 
-    - run: echo "::set-output name=version::$(php -v | awk 'NR==1{print $2}')"
+    - run: echo "version=$(php -v | awk 'NR==1{print $2}')" >> "$GITHUB_OUTPUT"
       shell: bash
       id: cache-magento-get-php-version
 
-    - run: echo "::set-output name=version::$(composer --version | awk '{print $3}')"
+    - run: echo "version=$(composer --version | awk '{print $3}')" >> "$GITHUB_OUTPUT"
       shell: bash
       name: Compute Composer Version
       id: cache-magento-get-composer-version


### PR DESCRIPTION
## What is the new behavior?
Addresses this github warning
> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
