### PR TITLE
feat(sansec-ecomscan): skip server checks by default

### DIFF
--- a/sansec-ecomscan/action.yml
+++ b/sansec-ecomscan/action.yml
@@ -17,6 +17,11 @@ inputs:
     default: 'true'
     description: "Skip the database scan (--skip-database). Defaults to true."
 
+  skip-server-checks:
+    required: false
+    default: 'true'
+    description: "Skip server / os level checks like copy-fail"
+
 runs:
   using: composite
   steps:
@@ -27,12 +32,13 @@ runs:
     - name: Fix permissions
       shell: bash
       run: chmod +x ecomscan
-
+  
     - name: Run eComscan
       shell: bash
       env:
         ECOMSCAN_KEY: ${{ inputs.license }}
       run: |
+        [ "${{ inputs.skip-server-checks }}" = "true" ] && export ECOMSCAN_SKIP_SERVER_CHECKS=true
         FLAGS=(--no-auto-update --deep --format=csv)
         [ "${{ inputs.skip_database }}" = "true" ] && FLAGS+=(--skip-database)
         output=$(./ecomscan "${FLAGS[@]}" "${{ inputs.path }}")


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/github-actions-magento2/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, CI fails because of `copy-fail`. [See the failing job.](https://github.com/graycoreio/github-actions-magento2/actions/runs/25387233218/job/74451685652)

> Security issues found:
2026-05-05T15:58:02Z,vulnerability,file:/opt/hostedtoolcache/setup-php/tools/composer,composer_command_injection,Composer 2.2.26
2026-05-05T15:58:02Z,vulnerability,Linux kernel,copy_fail,

Fixes: N/A


## What is the new behavior?
We don't care about running server checks in CI.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
