### PR TITLE
feat(setup-di-compile): restore setup-di-compile as a lean action

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,4 @@ Opinionated Github Actions and Workflows to make building, testing, and maintain
 | [Semver Compare](./semver-compare/README.md)                 | A Github Action that semantically compares two versions                                   |
 | [Supported Version](./supported-version/README.md)           | A Github Action that computes the currently supported Github Actions Matrix for Magento 2 |
 | [Setup Install](./setup-install/README.md)                   | A Github Action that runs `bin/magento setup:install` from the supported-version services matrix |
+| [Setup DI Compile](./setup-di-compile/README.md)             | A Github Action that enables all modules and runs `bin/magento setup:di:compile`                 |

--- a/setup-di-compile/README.md
+++ b/setup-di-compile/README.md
@@ -1,0 +1,58 @@
+# Setup DI Compile
+
+A GitHub Action that enables all Magento modules and runs `bin/magento setup:di:compile`.
+
+The caller is responsible for checkout, PHP/composer setup, and `composer install`. This action only performs the compilation step.
+
+## Inputs
+
+| Input  | Required | Default | Description                                                        |
+| ------ | -------- | ------- | ------------------------------------------------------------------ |
+| `path` | No       | `.`     | Path to the Magento root directory. |
+
+## Usage
+
+```yml
+name: DI Compile
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  compute_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.supported-version.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: graycoreio/github-actions-magento2/supported-version@main
+        id: supported-version
+
+  compile:
+    needs: compute_matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.compute_matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: graycoreio/github-actions-magento2/setup-magento@main
+        id: setup-magento
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v${{ matrix.composer }}
+
+      - uses: graycoreio/github-actions-magento2/cache-magento@main
+
+      - run: composer install
+        env:
+          COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
+
+      - uses: graycoreio/github-actions-magento2/setup-di-compile@main
+        with:
+          path: ${{ steps.setup-magento.outputs.path }}
+```

--- a/setup-di-compile/action.yml
+++ b/setup-di-compile/action.yml
@@ -1,0 +1,26 @@
+name: "Magento compilation (setup:di:compile)"
+author: "Graycore"
+description: "A GitHub Action that runs bin/magento setup:di:compile."
+
+inputs:
+  path:
+    required: false
+    default: "."
+    description: "Path to the Magento root directory. Accepts the output of the setup-magento action."
+
+runs:
+  using: composite
+  steps:
+    - name: Enable all modules
+      working-directory: ${{ inputs.path }}
+      shell: bash
+      run: php bin/magento module:enable --all
+
+    - name: Compile
+      working-directory: ${{ inputs.path }}
+      shell: bash
+      run: php bin/magento setup:di:compile
+
+branding:
+  icon: "tool"
+  color: "orange"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/github-actions-magento2/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `compile-extension` job in `check-extension.yaml` inlines `php bin/magento module:enable --all` and `php bin/magento setup:di:compile` directly. There is no reusable action for running DI compilation.

Fixes: N/A


## What is the new behavior?

A lean `setup-di-compile` action is restored that accepts a `path` input (defaulting to `.`) and runs:

1. `php bin/magento module:enable --all`
2. `php bin/magento setup:di:compile`

The caller is responsible for checkout, PHP/composer setup, and `composer install`. The `compile-extension` job in `check-extension.yaml` now delegates to this action instead of running the steps inline.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The action follows the same lean pattern as `coding-standard`: no embedded checkout, no embedded PHP setup, no `changed-files` gating — the action always runs unconditionally and the caller owns environment setup.
