### PR TITLE
feat(check-store): add initial check-store workflow

### DIFF
--- a/.github/workflows/_internal-check-store.yaml
+++ b/.github/workflows/_internal-check-store.yaml
@@ -1,0 +1,77 @@
+name: Check Store Test
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/_internal-check-store.yaml"
+      - ".github/workflows/check-store.yaml"
+      - "supported-version/**"
+      - "get-magento-version/**"
+      - "!(**/*.md)"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/_internal-check-store.yaml"
+      - ".github/workflows/check-store.yaml"
+      - "supported-version/**"
+      - "get-magento-version/**"
+      - "!(**/*.md)"
+
+jobs:
+  compute_matrix:
+    if: "!startsWith(github.head_ref, 'release-please')"
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.supported-version.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./supported-version
+        id: supported-version
+        with:
+          kind: currently-supported
+
+  prepare-fixture:
+    needs: compute_matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix: ${{ fromJSON(needs.compute_matrix.outputs.matrix) }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v${{ matrix.composer }}
+          coverage: none
+
+      - uses: ./cache-magento
+        with:
+          composer_cache_key: ${{ matrix.magento }}
+
+      - name: Create Magento store fixture
+        run: composer create-project --repository-url="https://mirror.mage-os.org/" "${{ matrix.magento }}" ./store-fixture
+
+      - name: Strip vendor from fixture
+        run: rm -rf ./store-fixture/vendor
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: store-fixture-${{ matrix.version }}
+          path: ./store-fixture
+          retention-days: 3
+
+  check-store:
+    needs: [compute_matrix, prepare-fixture]
+    strategy:
+      matrix: ${{ fromJSON(needs.compute_matrix.outputs.matrix) }}
+      fail-fast: false
+    uses: ./.github/workflows/check-store.yaml
+    with:
+      store_artifact_name: store-fixture-${{ matrix.version }}
+      path: "."
+      composer_cache_key: ${{ matrix.magento }}

--- a/.github/workflows/check-store.yaml
+++ b/.github/workflows/check-store.yaml
@@ -1,0 +1,164 @@
+name: MageCheck Store
+on:
+  workflow_call:
+    inputs:
+      path:
+        type: string
+        required: false
+        default: "."
+        description: "The folder of the Magento store that you are testing."
+
+      composer_cache_key:
+        type: string
+        required: false
+        default: "_mageos"
+        description: A key to version the composer cache. Can be incremented if you need to bust the cache.
+
+      store_artifact_name:
+        type: string
+        required: false
+        default: ""
+        description: "If provided, download store files from this artifact instead of using actions/checkout."
+
+    secrets:
+      composer_auth:
+        required: false
+        description: "Your composer credentials (typically a stringified json object of the contents of your auth.json)"
+
+jobs:
+  compute_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.supported-version.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+        if: inputs.store_artifact_name == ''
+
+      - uses: actions/download-artifact@v8
+        if: inputs.store_artifact_name != ''
+        with:
+          name: ${{ inputs.store_artifact_name }}
+          path: ${{ inputs.path }}
+
+      - uses: graycoreio/github-actions-magento2/get-magento-version@main
+        id: get-magento-version
+        with:
+          working-directory: ${{ inputs.path }}
+
+      - uses: graycoreio/github-actions-magento2/supported-version@main
+        id: supported-version
+        with:
+          kind: custom
+          custom_versions: ${{ steps.get-magento-version.outputs.project }}:${{ fromJSON(steps.get-magento-version.outputs.version) }}
+
+  unit-test:
+    runs-on: ${{ matrix.os }}
+    needs: compute_matrix
+    strategy:
+      matrix: ${{ fromJSON(needs.compute_matrix.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@v6
+        if: inputs.store_artifact_name == ''
+
+      - uses: actions/download-artifact@v8
+        if: inputs.store_artifact_name != ''
+        with:
+          name: ${{ inputs.store_artifact_name }}
+          path: ${{ inputs.path }}
+
+      - uses: graycoreio/github-actions-magento2/setup-magento@main
+        id: setup-magento
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v${{ matrix.composer }}
+          mode: store
+          working-directory: ${{ inputs.path }}
+          composer_auth: ${{ secrets.composer_auth }}
+
+      - uses: graycoreio/github-actions-magento2/cache-magento@main
+        with:
+          composer_cache_key: ${{ inputs.composer_cache_key }}
+
+      - name: Composer install
+        working-directory: ${{ steps.setup-magento.outputs.path }}
+        run: composer install
+        env:
+          COMPOSER_AUTH: ${{ secrets.composer_auth }}
+
+      - name: Configure phpunit.xml.dist
+        working-directory: ${{ steps.setup-magento.outputs.path }}
+        run: |
+          mkdir -p app/code
+
+          cat > /tmp/testsuite.xml << 'EOF'
+                  <testsuite name="Store_Unit_Tests">
+                      <directory>../../../app/code</directory>
+                  </testsuite>
+          EOF
+          sed -i '/<testsuites>/r /tmp/testsuite.xml' dev/tests/unit/phpunit.xml.dist
+
+          ## Disable allure (See https://github.com/magento/magento2/issues/36702 )
+          sed -i '/<extensions>/,/<\/extensions>/d' dev/tests/unit/phpunit.xml.dist
+
+      - name: Run unit tests
+        working-directory: ${{ steps.setup-magento.outputs.path }}
+        run: |
+          if find app/code -name "*Test.php" -print -quit | grep -q .; then
+            vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist --testsuite Store_Unit_Tests
+          else
+            echo "No unit tests found in app/code, skipping."
+          fi
+
+  coding-standard:
+    runs-on: ${{ matrix.os }}
+    needs: compute_matrix
+    strategy:
+      matrix: ${{ fromJSON(needs.compute_matrix.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@v6
+        if: inputs.store_artifact_name == ''
+
+      - uses: actions/download-artifact@v8
+        if: inputs.store_artifact_name != ''
+        with:
+          name: ${{ inputs.store_artifact_name }}
+          path: ${{ inputs.path }}
+
+      - uses: graycoreio/github-actions-magento2/setup-magento@main
+        id: setup-magento
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v${{ matrix.composer }}
+          mode: store
+          working-directory: ${{ inputs.path }}
+          composer_auth: ${{ secrets.composer_auth }}
+
+      - uses: graycoreio/github-actions-magento2/cache-magento@main
+        with:
+          composer_cache_key: ${{ inputs.composer_cache_key }}
+
+      - name: Composer install
+        working-directory: ${{ steps.setup-magento.outputs.path }}
+        run: composer install
+        env:
+          COMPOSER_AUTH: ${{ secrets.composer_auth }}
+
+      - name: Create default phpcs.xml if none exists
+        working-directory: ${{ steps.setup-magento.outputs.path }}
+        run: |
+          mkdir -p app/code
+          if [ ! -f .phpcs.xml ] && [ ! -f phpcs.xml ] && [ ! -f .phpcs.xml.dist ] && [ ! -f phpcs.xml.dist ]; then
+            cat > phpcs.xml << 'EOF'
+            <ruleset name="Store">
+                <rule ref="Magento2"/>
+                <file>app/code</file>
+            </ruleset>
+          EOF
+          fi
+
+      - uses: graycoreio/github-actions-magento2/coding-standard@main
+        with:
+          path: ${{ steps.setup-magento.outputs.path }}
+          composer_auth: ${{ secrets.composer_auth }}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/github-actions-magento2/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: N/A

There is no reusable workflow for running CI checks against a Magento store project. The existing `check-extension` workflow is scoped to extensions and requires an externally-computed matrix.


## What is the new behavior?

Adds a new `check-store` reusable workflow that runs unit tests and coding standards against a Magento store repository.

- Auto-detects the store's Magento version from `composer.json` via `get-magento-version`
- Computes a compatible PHP/composer matrix via `supported-version` (`kind: custom`)
- Runs `vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist` for unit tests
- Runs Magento coding standards via the `coding-standard` action
- Accepts an optional `store_artifact_name` input to download store files from a GitHub Actions artifact instead of using `actions/checkout`, enabling testing against dynamically created fixtures

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The `store_artifact_name` input is intended primarily for internal testing. Store teams using this workflow in their own repos should omit it and rely on the default `actions/checkout` behavior.
