### PR TITLE
Setup magento changes

### DIFF
--- a/setup-magento/action.yml
+++ b/setup-magento/action.yml
@@ -68,7 +68,7 @@ runs:
     - run: |
         MAGENTO_DIRECTORY=""
         if [ "${{ inputs.mode }}" = 'extension' ]; then
-            MAGENTO_DIRECTORY="../magento2"
+            MAGENTO_DIRECTORY="_ghamagento"
         else
             MAGENTO_DIRECTORY="${{ inputs.working-directory }}"
         fi

--- a/setup-magento/action.yml
+++ b/setup-magento/action.yml
@@ -90,6 +90,11 @@ runs:
       env:
         COMPOSER_AUTH: ${{ inputs.composer_auth }}
 
+    - run: mkdir -p ${{ steps.setup-magento-compute-directory.outputs.MAGENTO_DIRECTORY }}/app/etc
+      shell: bash
+      name: Ensure app/etc exists for magento composer plugin
+      if: inputs.mode == 'extension'
+
     - uses: graycoreio/github-actions-magento2/fix-magento-install@main
       name: Fix Magento Out of Box Install Issues
       with:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/github-actions-magento2/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When `setup-magento` runs in `extension` mode:

1. The Magento 2 repo is checked out to `../magento2`, which lives **outside** the extension's `GITHUB_WORKSPACE`. This is incompatible with `cache-magento`, which can only cache paths inside the workspace.
2. `app/etc` does not exist at the time `magento/composer-plugin` runs, which causes the plugin to crash when caching is involved.

Fixes: N/A


## What is the new behavior?

1. In `extension` mode, `setup-magento` now uses `_ghamagento` (inside `GITHUB_WORKSPACE`) as the Magento working directory instead of `../magento2`. This keeps the install on a path that `cache-magento` can see and restore.
2. `app/etc` is pre-created (`mkdir -p`) in `extension` mode before downstream steps run, so `magento/composer-plugin` no longer crashes during cached runs.

Consumers reading `steps.setup-magento.outputs.path` are unaffected — only callers who hardcoded `../magento2` need to update.


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

**Impact:** Any workflow that hardcoded `../magento2` as the Magento install path while using `setup-magento` in `extension` mode will break.

**Migration:** Replace hardcoded `../magento2` references with `${{ steps.setup-magento.outputs.path }}` (where `setup-magento` is the `id` of your `setup-magento` step). Workflows already using the `outputs.path` value require no changes.


## Other information

Both commits are scoped to `setup-magento/action.yml` and only affect `extension` mode; `store` mode behavior is unchanged.
