### PR TITLE
feat(check-store): forward stamp input to cache-magento

### DIFF
--- a/.github/workflows/_internal-check-store.yaml
+++ b/.github/workflows/_internal-check-store.yaml
@@ -43,26 +43,49 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: shivammathur/setup-php@v2
+      - uses: ./setup-magento
+        id: setup-magento
         with:
           php-version: ${{ matrix.php }}
           tools: composer:v${{ matrix.composer }}
-          coverage: none
+          magento_version: ${{ matrix.magento }}
+          mode: extension
+
+      - run: composer update --no-install
+        working-directory: ${{ steps.setup-magento.outputs.path }}
 
       - uses: ./cache-magento
         with:
           composer_cache_key: ${{ matrix.magento }}
+          working-directory: ${{ steps.setup-magento.outputs.path }}
+          stamp: true
 
-      - name: Create Magento store fixture
-        run: composer create-project --repository-url="https://mirror.mage-os.org/" "${{ matrix.magento }}" ./store-fixture
+      - name: Inspect stamp cache contents
+        if: always()
+        working-directory: ${{ steps.setup-magento.outputs.path }}
+        run: |
+          echo "=== top-level vendor/magento ==="
+          ls vendor/magento/ 2>/dev/null | head -30 || echo "(no vendor/magento)"
+          echo
+          echo "=== magento2-base presence ==="
+          if [ -d vendor/magento/magento2-base ]; then
+            echo "PRESENT — file count: $(find vendor/magento/magento2-base -type f | wc -l)"
+          else
+            echo "ABSENT (negation worked)"
+          fi
+          echo
+          echo "=== installed.json mentions magento/magento2-base ==="
+          grep -c '"name": "magento/magento2-base"' vendor/composer/installed.json 2>/dev/null || echo 0
 
-      - name: Strip vendor from fixture
-        run: rm -rf ./store-fixture/vendor
+      - run: composer install
+        working-directory: ${{ steps.setup-magento.outputs.path }}
 
       - uses: actions/upload-artifact@v7
         with:
           name: store-fixture-${{ matrix.version }}
-          path: ./store-fixture
+          path: |
+            ${{ steps.setup-magento.outputs.path }}
+            !${{ steps.setup-magento.outputs.path }}/vendor
           retention-days: 3
 
   check-store:
@@ -73,5 +96,6 @@ jobs:
     uses: ./.github/workflows/check-store.yaml
     with:
       store_artifact_name: store-fixture-${{ matrix.version }}
-      path: "."
+      path: "_ghamagento/"
       composer_cache_key: ${{ matrix.magento }}
+      stamp: true

--- a/.github/workflows/check-store.yaml
+++ b/.github/workflows/check-store.yaml
@@ -82,7 +82,7 @@ jobs:
           working-directory: ${{ inputs.path }}
           composer_auth: ${{ secrets.composer_auth }}
 
-      - uses: graycoreio/github-actions-magento2/cache-magento@cache-magento-overhaul
+      - uses: graycoreio/github-actions-magento2/cache-magento@main
         with:
           composer_cache_key: ${{ inputs.composer_cache_key }}
           working-directory: ${{ steps.setup-magento.outputs.path }}
@@ -143,7 +143,7 @@ jobs:
           working-directory: ${{ inputs.path }}
           composer_auth: ${{ secrets.composer_auth }}
 
-      - uses: graycoreio/github-actions-magento2/cache-magento@cache-magento-overhaul
+      - uses: graycoreio/github-actions-magento2/cache-magento@main
         with:
           composer_cache_key: ${{ inputs.composer_cache_key }}
           working-directory: ${{ steps.setup-magento.outputs.path }}

--- a/.github/workflows/check-store.yaml
+++ b/.github/workflows/check-store.yaml
@@ -20,6 +20,12 @@ on:
         default: ""
         description: "If provided, download store files from this artifact instead of using actions/checkout."
 
+      stamp:
+        type: boolean
+        required: false
+        default: false
+        description: "Cache the vendor/ directory in addition to the Composer download cache."
+
     secrets:
       composer_auth:
         required: false
@@ -76,9 +82,11 @@ jobs:
           working-directory: ${{ inputs.path }}
           composer_auth: ${{ secrets.composer_auth }}
 
-      - uses: graycoreio/github-actions-magento2/cache-magento@main
+      - uses: graycoreio/github-actions-magento2/cache-magento@cache-magento-overhaul
         with:
           composer_cache_key: ${{ inputs.composer_cache_key }}
+          working-directory: ${{ steps.setup-magento.outputs.path }}
+          stamp: ${{ inputs.stamp }}
 
       - name: Composer install
         working-directory: ${{ steps.setup-magento.outputs.path }}
@@ -135,9 +143,11 @@ jobs:
           working-directory: ${{ inputs.path }}
           composer_auth: ${{ secrets.composer_auth }}
 
-      - uses: graycoreio/github-actions-magento2/cache-magento@main
+      - uses: graycoreio/github-actions-magento2/cache-magento@cache-magento-overhaul
         with:
           composer_cache_key: ${{ inputs.composer_cache_key }}
+          working-directory: ${{ steps.setup-magento.outputs.path }}
+          stamp: ${{ inputs.stamp }}
 
       - name: Composer install
         working-directory: ${{ steps.setup-magento.outputs.path }}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/github-actions-magento2/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`check-store.yaml` calls `cache-magento` with only `composer_cache_key`. Even after `cache-magento` learned to cache the extracted `vendor/` directory via `stamp: true`, callers of the public reusable workflow had no way to opt in.

Fixes: N/A


## What is the new behavior?

`check-store.yaml` exposes a new optional input:

| Input   | Type    | Default | Description                                                |
| ------- | ------- | ------- | ---------------------------------------------------------- |
| `stamp` | boolean | `false` | Cache the `vendor/` directory in addition to the download cache. |

When set, the workflow forwards `stamp` and `working-directory: ${{ steps.setup-magento.outputs.path }}` to `cache-magento`. Both jobs in `check-store.yaml` (`coding-standard` and the main `check-store` job) are wired identically.

Internal CI (`_internal-check-store.yaml`) is updated to call the workflow with `stamp: true`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

`stamp` defaults to `false`, so existing callers see no behavior change.

## Other information

The "warning" callout from `cache-magento`'s README applies here too: enabling `stamp` for Dependabot/Renovate runs is wasteful — gate on `${{ github.actor != 'dependabot[bot]' }}` if you adopt this in a busy repo.
