### PR TITLE
feat(check-extension): enable stamp caching

### DIFF
--- a/.github/workflows/_internal_check_extension.yaml
+++ b/.github/workflows/_internal_check_extension.yaml
@@ -39,3 +39,4 @@ jobs:
     with:
       path: _test/demo-package
       matrix: ${{ needs.compute_matrix.outputs.matrix }}
+      stamp: true

--- a/.github/workflows/check-extension.yaml
+++ b/.github/workflows/check-extension.yaml
@@ -50,7 +50,7 @@ jobs:
         steps:
         - uses: actions/checkout@v6
 
-        - uses: graycoreio/github-actions-magento2/setup-magento@cache-magento-overhaul
+        - uses: graycoreio/github-actions-magento2/setup-magento@main
           id: setup-magento
           with:
             php-version: ${{ matrix.php }}
@@ -75,7 +75,7 @@ jobs:
         - run: composer update --no-install
           working-directory: ${{ steps.setup-magento.outputs.path }}
 
-        - uses: graycoreio/github-actions-magento2/cache-magento@cache-magento-overhaul
+        - uses: graycoreio/github-actions-magento2/cache-magento@main
           with:
             composer_cache_key: ${{ inputs.composer_cache_key && format('{0} | {1}', inputs.composer_cache_key, matrix.magento) || matrix.magento }}
             working-directory: ${{ steps.setup-magento.outputs.path }}
@@ -115,7 +115,7 @@ jobs:
         steps:
         - uses: actions/checkout@v6
 
-        - uses: graycoreio/github-actions-magento2/setup-magento@cache-magento-overhaul
+        - uses: graycoreio/github-actions-magento2/setup-magento@main
           id: setup-magento
           with:
             php-version: ${{ matrix.php }}
@@ -142,7 +142,7 @@ jobs:
         - run: composer update --no-install
           working-directory: ${{ steps.setup-magento.outputs.path }}
 
-        - uses: graycoreio/github-actions-magento2/cache-magento@cache-magento-overhaul
+        - uses: graycoreio/github-actions-magento2/cache-magento@main
           with:
             composer_cache_key: ${{ inputs.composer_cache_key && format('{0} | {1}', inputs.composer_cache_key, matrix.magento) || matrix.magento }}
             working-directory: ${{ steps.setup-magento.outputs.path }}
@@ -173,7 +173,7 @@ jobs:
           tools: composer:v${{ matrix.composer }}
           coverage: none
 
-      - uses: graycoreio/github-actions-magento2/cache-magento@cache-magento-overhaul
+      - uses: graycoreio/github-actions-magento2/cache-magento@main
         with:
           composer_cache_key: ${{ inputs.composer_cache_key && format('{0} | {1}', inputs.composer_cache_key, matrix.magento) || matrix.magento }}
 
@@ -191,7 +191,7 @@ jobs:
       steps:
       - uses: actions/checkout@v6
 
-      - uses: graycoreio/github-actions-magento2/setup-magento@cache-magento-overhaul
+      - uses: graycoreio/github-actions-magento2/setup-magento@main
         id: setup-magento
         with:
           php-version: ${{ matrix.php }}
@@ -218,7 +218,7 @@ jobs:
       - run: composer update --no-install
         working-directory: ${{ steps.setup-magento.outputs.path }}
 
-      - uses: graycoreio/github-actions-magento2/cache-magento@cache-magento-overhaul
+      - uses: graycoreio/github-actions-magento2/cache-magento@main
         with:
           composer_cache_key: ${{ inputs.composer_cache_key && format('{0} | {1}', inputs.composer_cache_key, matrix.magento) || matrix.magento }}
           working-directory: ${{ steps.setup-magento.outputs.path }}

--- a/.github/workflows/check-extension.yaml
+++ b/.github/workflows/check-extension.yaml
@@ -27,8 +27,14 @@ on:
     composer_cache_key:
         type: string
         required: false
-        default: "_mageos"
+        default: ""
         description: A key to version the composer cache. Can be incremented if you need to bust the cache.
+
+    stamp:
+        type: boolean
+        required: false
+        default: false
+        description: "Cache the vendor/ directory in addition to the Composer download cache."
 
   secrets:
     composer_auth:
@@ -44,7 +50,7 @@ jobs:
         steps:
         - uses: actions/checkout@v6
 
-        - uses: graycoreio/github-actions-magento2/setup-magento@main
+        - uses: graycoreio/github-actions-magento2/setup-magento@cache-magento-overhaul
           id: setup-magento
           with:
             php-version: ${{ matrix.php }}
@@ -53,10 +59,6 @@ jobs:
             magento_version: ${{ matrix.magento }}
             magento_repository: ${{ inputs.magento_repository }}
             composer_auth: ${{ secrets.composer_auth }}
-
-        - uses: graycoreio/github-actions-magento2/cache-magento@main
-          with:
-            composer_cache_key: ${{ inputs.composer_cache_key }}
 
         - name: Add extension repository
           working-directory: ${{ steps.setup-magento.outputs.path }}
@@ -69,6 +71,15 @@ jobs:
         - name: Require extension
           working-directory: ${{ steps.setup-magento.outputs.path }}
           run: composer require "${{ steps.package.outputs.name }}:@dev" --no-install
+
+        - run: composer update --no-install
+          working-directory: ${{ steps.setup-magento.outputs.path }}
+
+        - uses: graycoreio/github-actions-magento2/cache-magento@cache-magento-overhaul
+          with:
+            composer_cache_key: ${{ inputs.composer_cache_key && format('{0} | {1}', inputs.composer_cache_key, matrix.magento) || matrix.magento }}
+            working-directory: ${{ steps.setup-magento.outputs.path }}
+            stamp: ${{ inputs.stamp }}
 
         - name: Composer install
           working-directory: ${{ steps.setup-magento.outputs.path }}
@@ -104,7 +115,7 @@ jobs:
         steps:
         - uses: actions/checkout@v6
 
-        - uses: graycoreio/github-actions-magento2/setup-magento@main
+        - uses: graycoreio/github-actions-magento2/setup-magento@cache-magento-overhaul
           id: setup-magento
           with:
             php-version: ${{ matrix.php }}
@@ -113,10 +124,6 @@ jobs:
             magento_version: ${{ matrix.magento }}
             magento_repository: ${{ inputs.magento_repository }}
             composer_auth: ${{ secrets.composer_auth }}
-
-        - uses: graycoreio/github-actions-magento2/cache-magento@main
-          with:
-            composer_cache_key: ${{ inputs.composer_cache_key }}
 
         - name: Add extension repository
           working-directory: ${{ steps.setup-magento.outputs.path }}
@@ -131,6 +138,15 @@ jobs:
           run: composer require "${{ steps.package.outputs.name }}:@dev" --no-install
           env:
             COMPOSER_AUTH: ${{ secrets.composer_auth }}
+
+        - run: composer update --no-install
+          working-directory: ${{ steps.setup-magento.outputs.path }}
+
+        - uses: graycoreio/github-actions-magento2/cache-magento@cache-magento-overhaul
+          with:
+            composer_cache_key: ${{ inputs.composer_cache_key && format('{0} | {1}', inputs.composer_cache_key, matrix.magento) || matrix.magento }}
+            working-directory: ${{ steps.setup-magento.outputs.path }}
+            stamp: ${{ inputs.stamp }}
 
         - name: Composer install
           working-directory: ${{ steps.setup-magento.outputs.path }}
@@ -157,6 +173,10 @@ jobs:
           tools: composer:v${{ matrix.composer }}
           coverage: none
 
+      - uses: graycoreio/github-actions-magento2/cache-magento@cache-magento-overhaul
+        with:
+          composer_cache_key: ${{ inputs.composer_cache_key && format('{0} | {1}', inputs.composer_cache_key, matrix.magento) || matrix.magento }}
+
       - uses: graycoreio/github-actions-magento2/coding-standard@main
         with:
           path: ${{ inputs.path }}
@@ -171,7 +191,7 @@ jobs:
       steps:
       - uses: actions/checkout@v6
 
-      - uses: graycoreio/github-actions-magento2/setup-magento@main
+      - uses: graycoreio/github-actions-magento2/setup-magento@cache-magento-overhaul
         id: setup-magento
         with:
           php-version: ${{ matrix.php }}
@@ -180,10 +200,6 @@ jobs:
           magento_version: ${{ matrix.magento }}
           magento_repository: ${{ inputs.magento_repository }}
           composer_auth: ${{ secrets.composer_auth }}
-
-      - uses: graycoreio/github-actions-magento2/cache-magento@main
-        with:
-          composer_cache_key: ${{ inputs.composer_cache_key }}
 
       - name: Add extension repository
         working-directory: ${{ steps.setup-magento.outputs.path }}
@@ -198,6 +214,15 @@ jobs:
         run: composer require "${{ steps.package.outputs.name }}:@dev" --no-install
         env:
           COMPOSER_AUTH: ${{ secrets.composer_auth }}
+
+      - run: composer update --no-install
+        working-directory: ${{ steps.setup-magento.outputs.path }}
+
+      - uses: graycoreio/github-actions-magento2/cache-magento@cache-magento-overhaul
+        with:
+          composer_cache_key: ${{ inputs.composer_cache_key && format('{0} | {1}', inputs.composer_cache_key, matrix.magento) || matrix.magento }}
+          working-directory: ${{ steps.setup-magento.outputs.path }}
+          stamp: ${{ inputs.stamp }}
 
       - name: Composer install
         working-directory: ${{ steps.setup-magento.outputs.path }}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/github-actions-magento2/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`check-extension.yaml` calls `cache-magento` immediately after `setup-magento`, before `composer require`/`composer update`. With the new stamp-cache feature in `cache-magento`, the cache key includes a `composer.lock` hash for store-mode projects — but at the point the cache step runs there is no `composer.lock` yet because the extension hasn't been added to the project. So even if a user wanted vendor-stamp caching, the key would be unstable.

The default `composer_cache_key` is also `_mageos`, which is the same value across every Magento version, so download caches from a 2.4.6 run can be restored into a 2.4.8 run.

Fixes: N/A


## What is the new behavior?

`check-extension.yaml` exposes a new optional input:

| Input   | Type    | Default | Description                                                |
| ------- | ------- | ------- | ---------------------------------------------------------- |
| `stamp` | boolean | `false` | Cache the `vendor/` directory in addition to the download cache. |

Three callsite-level changes:

1. The `cache-magento` step is moved **after** `composer require ${{ steps.package.outputs.name }}:@dev --no-install` and a new `composer update --no-install` step. The lock file now exists when the cache key is computed.
2. The `cache-magento` step forwards `working-directory: ${{ steps.setup-magento.outputs.path }}` and `stamp: ${{ inputs.stamp }}`.
3. The `composer_cache_key` default flips from `"_mageos"` to `""`. When empty, the workflow falls back to `matrix.magento` so caches are bucketed per Magento version automatically. Callers that explicitly set `composer_cache_key` get `<their-key> | <matrix.magento>` so they still segment per version.

The `compile-extension` job also gains a `cache-magento` step (it didn't have one) so its `composer install` benefits from the download cache.

Internal CI (`_internal_check_extension.yaml`) is updated to call the workflow with `stamp: true`.

The `cache-magento` and `setup-magento` `uses:` references temporarily point at `@cache-magento-overhaul`. They will be flipped back to `@main` once that branch is merged.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

`stamp` defaults to `false`. The `composer_cache_key` default change from `"_mageos"` to `""` is a behavioral change but not a breaking one — anyone who explicitly passed a value still gets it (now combined with `matrix.magento`), and anyone relying on the default gets a more correct, version-segmented key. The worst-case effect is a one-time cache miss on first run.
