### PR TITLE
ci(setup-install): adopt cache-magento stamp cache

### DIFF
--- a/.github/workflows/_internal-setup-install.yaml
+++ b/.github/workflows/_internal-setup-install.yaml
@@ -54,10 +54,15 @@ jobs:
         magento_version: ${{ matrix.magento }}
         magento_repository: "https://mirror.mage-os.org/"
         composer_auth: ${{ secrets.COMPOSER_AUTH }}
+    
+    - run: composer update --no-install
+      working-directory: ${{ steps.setup-magento.outputs.path }}
 
     - uses: ./cache-magento
       with:
         composer_cache_key: ${{ matrix.magento }}
+        working-directory: ${{ steps.setup-magento.outputs.path }}
+        stamp: true
 
     - name: Add extension repository
       working-directory: ${{ steps.setup-magento.outputs.path }}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/github-actions-magento2/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`_internal-setup-install.yaml` calls `cache-magento` with only `composer_cache_key`. Each run pays the full Composer install time.

Fixes: N/A


## What is the new behavior?

The internal setup-install workflow now:

1. Runs `composer update --no-install` after `setup-magento` so a `composer.lock` exists at the moment the cache key is computed.
2. Calls `cache-magento` with `working-directory: ${{ steps.setup-magento.outputs.path }}` and `stamp: true` so the extracted `vendor/` is cached alongside the Composer download cache.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Internal-only workflow; no public surface change.

## Other information

This is one of several internal CI workflows being migrated to the stamp cache; see also `sansec-ecomscan-stamp` and `setup-magento-test-rework`.
