### PR TITLE
feat(check-store): add smoke-test action and use resolve-check-config

### DIFF
--- a/.github/workflows/check-store.yaml
+++ b/.github/workflows/check-store.yaml
@@ -35,7 +35,7 @@ jobs:
   compute_matrix:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.supported-version.outputs.matrix }}
+      resolved: ${{ steps.resolve.outputs.resolved }}
     steps:
       - uses: actions/checkout@v6
         if: inputs.store_artifact_name == ''
@@ -57,11 +57,18 @@ jobs:
           kind: custom
           custom_versions: ${{ steps.get-magento-version.outputs.project }}:${{ fromJSON(steps.get-magento-version.outputs.version) }}
 
+      - uses: graycoreio/github-actions-magento2/resolve-check-config@main
+        id: resolve
+        with:
+          kind: store
+          matrix: ${{ steps.supported-version.outputs.matrix }}
+
   unit-test:
     runs-on: ${{ matrix.os }}
     needs: compute_matrix
+    if: ${{ fromJSON(needs.compute_matrix.outputs.resolved)['unit-test'].enabled != false }}
     strategy:
-      matrix: ${{ fromJSON(needs.compute_matrix.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.compute_matrix.outputs.resolved)['unit-test'].matrix }}
 
     steps:
       - uses: actions/checkout@v6
@@ -122,8 +129,9 @@ jobs:
   coding-standard:
     runs-on: ${{ matrix.os }}
     needs: compute_matrix
+    if: ${{ fromJSON(needs.compute_matrix.outputs.resolved)['coding-standard'].enabled != false }}
     strategy:
-      matrix: ${{ fromJSON(needs.compute_matrix.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.compute_matrix.outputs.resolved)['coding-standard'].matrix }}
 
     steps:
       - uses: actions/checkout@v6
@@ -173,3 +181,63 @@ jobs:
         with:
           path: ${{ steps.setup-magento.outputs.path }}
           composer_auth: ${{ secrets.composer_auth }}
+
+  smoke-test:
+    runs-on: ${{ matrix.os }}
+    needs: compute_matrix
+    if: ${{ fromJSON(needs.compute_matrix.outputs.resolved)['smoke-test'].enabled != false }}
+    services: ${{ matrix.services }}
+    strategy:
+      matrix: ${{ fromJSON(needs.compute_matrix.outputs.resolved)['smoke-test'].matrix }}
+
+    steps:
+      - uses: actions/checkout@v6
+        if: inputs.store_artifact_name == ''
+
+      - uses: actions/download-artifact@v8
+        if: inputs.store_artifact_name != ''
+        with:
+          name: ${{ inputs.store_artifact_name }}
+          path: ${{ inputs.path }}
+
+      - uses: graycoreio/github-actions-magento2/setup-magento@main
+        id: setup-magento
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v${{ matrix.composer }}
+          mode: store
+          working-directory: ${{ inputs.path }}
+          composer_auth: ${{ secrets.composer_auth }}
+
+      - uses: graycoreio/github-actions-magento2/cache-magento@main
+        with:
+          composer_cache_key: ${{ inputs.composer_cache_key }}
+          working-directory: ${{ steps.setup-magento.outputs.path }}
+          stamp: ${{ inputs.stamp }}
+
+      - name: Composer install
+        working-directory: ${{ steps.setup-magento.outputs.path }}
+        run: composer install
+        env:
+          COMPOSER_AUTH: ${{ secrets.composer_auth }}
+
+      - uses: graycoreio/github-actions-magento2/setup-install@main
+        id: setup-install
+        with:
+          services: ${{ toJSON(matrix.services) }}
+          path: ${{ steps.setup-magento.outputs.path }}
+          container_id: ${{ job.services['php-fpm'].id }}
+          extra_args: --magento-init-params=MAGE_MODE=developer
+
+      - uses: graycoreio/github-actions-magento2/configure-service-nginx@main
+        with:
+          container_id: ${{ job.services.nginx.id }}
+          magento_path: ${{ inputs.path }}
+
+      - uses: graycoreio/github-actions-magento2/smoke-test@main
+        with:
+          kind: page
+
+      - uses: graycoreio/github-actions-magento2/smoke-test@main
+        with:
+          kind: graphql

--- a/docs/workflows/check-store.md
+++ b/docs/workflows/check-store.md
@@ -24,6 +24,24 @@ See the [check-store.yaml](../../.github/workflows/check-store.yaml)
 
 - **Unit Tests** — runs PHPUnit against custom code in `app/code`. Skipped automatically if no test files are found.
 - **Coding Standard** — runs the Magento Coding Standard against `app/code`. Uses your `phpcs.xml` (or `.phpcs.xml`, `phpcs.xml.dist`, `.phpcs.xml.dist`) if one exists, otherwise a sensible default is generated.
+- **Smoke Test** — boots your store against the supported-version service set (mysql, search, queue, cache, nginx, php-fpm) and runs the smoke probes against it.
+
+## Configuration
+
+Each check can be toggled on/off through an optional `.github/check-store.json` file in the repo that calls this workflow. 
+
+You can learn more about this file here in the [`resolve-check-config` action.](../../resolve-check-config/README.md): 
+
+Reference the published JSON Schema with `$schema` to get autocompletion and inline validation in editors that support it:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/graycoreio/github-actions-magento2/main/resolve-check-config/check-store.schema.json",
+  "jobs": {
+    "coding-standard": false
+  }
+}
+```
 
 ## Usage
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/github-actions-magento2/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

`check-store.yaml` runs `unit-test` and `coding-standard` against every supported Magento version produced by `supported-version`. There is no smoke check, so a store can be lint-clean and unit-test-green yet still fail to boot. There is also no caller-facing knob to disable individual checks per-project.

Fixes: N/A


## What is the new behavior?

- Adds a `smoke-test` job to `check-store.yaml` that:
  - Brings up the full per-version service set (`mysql`, `search`, `queue`, `cache`, `nginx`, `php-fpm`) from the supported-version matrix.
  - Runs `setup:install` inside the `php-fpm` service container.
  - Configures the `nginx` service container against the installed Magento path.
  - Fires both `page` and `graphql` smoke probes against the running store.
- Routes the workflow's matrix through the existing `resolve-check-config` action. `compute_matrix` now emits a single `resolved` output (per-job filtered matrix) and every downstream job:
  - Gates on `fromJSON(...)['<job>'].enabled != false`, so callers can disable a check by adding it to `.github/check-store.json`.
  - Pulls its `strategy.matrix` from `resolved['<job>'].matrix`, which already has each entry's `services` map filtered to the tiers that job needs.
- Updates `docs/workflows/check-store.md`:
  - Adds the smoke-test bullet to **Checks Run**.
  - Adds a **Configuration** section documenting `.github/check-store.json`, including a `$schema`-referenced example for editor autocompletion / validation.
  - Cross-links to the `resolve-check-config` action README for the full config surface.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

`check-store.yaml`'s public inputs and secrets are unchanged. The new `smoke-test` job runs by default; callers can opt out by adding `{ "jobs": { "smoke-test": false } }` to `.github/check-store.json`.


## Other information

- Companion actions used by the new smoke-test job (`setup-install`, `configure-service-nginx`, `smoke-test`) are already on `main`; the workflow pins them to `@main`.
- Per-job matrix filtering means that, for example, `unit-test` no longer spins up unused service containers — its matrix entries carry `services: {}`.
