### PR TITLE
fix(check-extension): limit coding-standard to latest Magento

### DIFF
--- a/.github/workflows/check-extension.yaml
+++ b/.github/workflows/check-extension.yaml
@@ -165,10 +165,21 @@ jobs:
           with:
             path: ${{ steps.setup-magento.outputs.path }}
 
+    compute_latest_matrix:
+      runs-on: ubuntu-latest
+      outputs:
+        matrix: ${{ steps.supported-version.outputs.matrix }}
+      steps:
+        - uses: graycoreio/github-actions-magento2/supported-version@main
+          id: supported-version
+          with:
+            kind: latest
+
     coding-standard:
       runs-on:  ${{ matrix.os }}
+      needs: compute_latest_matrix
       strategy:
-          matrix: ${{ fromJSON(inputs.matrix) }}
+          matrix: ${{ fromJSON(needs.compute_latest_matrix.outputs.matrix) }}
           fail-fast: ${{ inputs.fail-fast }}
       steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/github-actions-magento2/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently `check-extension` runs the `coding-standard` against all versions of Magento, this is pointless ci effort.

## What is the new behavior?
We only run against the latest version of Magento.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

